### PR TITLE
fix: remove stale veterinary helpers from api.ts

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -53,15 +53,8 @@ export function field(record: any, key: string): any {
   return record?.data?.[key] ?? null;
 }
 
-export async function fetchOwners() { return apiFetch('owners'); }
-export async function fetchPets() { return apiFetch('pets'); }
-export async function fetchSpecies() { return apiFetch('species'); }
-export async function fetchVets() { return apiFetch('vets'); }
 export async function fetchServices() { return apiFetch('services'); }
 export async function fetchAppointments() { return apiFetch('appointments'); }
-export async function fetchVisits() { return apiFetch('visits'); }
-export async function fetchProducts() { return apiFetch('products'); }
-export async function fetchTestimonials() { return apiFetch('testimonials'); }
 
 export async function fetchSiteConfig(): Promise<Record<string, any>> {
   const records = await apiFetch('site_config');
@@ -103,22 +96,6 @@ export function resolve(record: any, relKey: string, lookup: Record<string, any>
 export function resolveDisplayName(record: any, relKey: string, lookup: Record<string, any>): string {
   const related = resolve(record, relKey, lookup);
   return getRecordDisplayName(related);
-}
-
-export function getPetDisplayName(pet: any): string {
-  return field(pet, 'name') || 'Sin nombre';
-}
-
-export function getOwnerFullName(owner: any): string {
-  const first = field(owner, 'first_name') || '';
-  const last = field(owner, 'last_name') || '';
-  return `${first} ${last}`.trim() || 'Desconocido';
-}
-
-export function getVetFullName(vet: any): string {
-  const first = field(vet, 'first_name') || '';
-  const last = field(vet, 'last_name') || '';
-  return `${first} ${last}`.trim() || 'Desconocido';
 }
 
 export function formatDate(dateStr: string | null): string {


### PR DESCRIPTION
## Summary
Closes #1

Removes 10 dead functions from `src/lib/api.ts` that were leftover from the veterinary app template: `fetchOwners`, `fetchPets`, `fetchSpecies`, `fetchVets`, `fetchVisits`, `fetchProducts`, `fetchTestimonials`, `getPetDisplayName`, `getOwnerFullName`, `getVetFullName`.

## Changes
- Removed 7 fetch functions for veterinary entities (lines 56-64)
- Removed 3 display-name helpers for vet/pet/owner (lines 108-121)
- All consultorio-relevant functions preserved: `fetchServices`, `fetchAppointments`, `fetchSiteConfig`, `field`, `buildLookup`, `getRecordDisplayName`, `resolve`, `resolveDisplayName`, `formatDate`, `formatDateTime`, `formatPrice`

## Test Plan
- [x] Verified no other file imports the removed functions (grep across entire repo)
- [x] Ran `npx tsc --noEmit` -- no type errors introduced
- [ ] Verify `fetchServices()` and `fetchAppointments()` still work at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)