### PR TITLE
feat: migrate apiUpdate to PATCH, add apiReplace for PUT

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -59,7 +59,24 @@ export async function apiCreate(entity: string, data: Record<string, any>): Prom
   return json?.data || json;
 }
 
+// Partial update — sends only the fields provided (PATCH semantics)
 export async function apiUpdate(entity: string, id: string, data: Record<string, any>): Promise<any> {
+  const res = await fetch(`${BASE_URL}/api/entities/${entity}/records/${id}`, {
+    method: 'PATCH',
+    headers: getHeaders(),
+    body: JSON.stringify(data),
+  });
+  if (res.status === 401) { handleUnauthorized(); return null; }
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to update ${entity}/${id}: ${res.status} ${text}`);
+  }
+  const json = await res.json();
+  return json?.data || json;
+}
+
+// Full replacement — overwrites the entire record (PUT semantics)
+export async function apiReplace(entity: string, id: string, data: Record<string, any>): Promise<any> {
   const res = await fetch(`${BASE_URL}/api/entities/${entity}/records/${id}`, {
     method: 'PUT',
     headers: getHeaders(),
@@ -68,7 +85,7 @@ export async function apiUpdate(entity: string, id: string, data: Record<string,
   if (res.status === 401) { handleUnauthorized(); return null; }
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Failed to update ${entity}/${id}: ${res.status} ${text}`);
+    throw new Error(`Failed to replace ${entity}/${id}: ${res.status} ${text}`);
   }
   const json = await res.json();
   return json?.data || json;


### PR DESCRIPTION
## Summary

Closes #2.

Migrates `apiUpdate` from `PUT` to `PATCH` method for partial updates, matching how all callers already use it (sending only changed fields). Adds a new `apiReplace` function with `PUT` semantics as an escape hatch for full record replacement.

## Changes

- Changed `apiUpdate` HTTP method from `PUT` to `PATCH`
- Added `apiReplace` function using `PUT` for full replacement
- Added comments clarifying PATCH = partial update, PUT = full replace

## Test Plan

- [ ] Verify appointment status updates work correctly (PATCH)
- [ ] Verify doctor schedule saves work correctly (PATCH)
- [ ] Verify patient modal edits work correctly (PATCH)
- [ ] Verify CrudForm updates work correctly (PATCH)
- [ ] Verify site config editor saves work correctly (PATCH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)