### PR TITLE
feat: add computed rule for patient full name

### DIFF
--- a/docs/rules-changelog.md
+++ b/docs/rules-changelog.md
@@ -9,3 +9,11 @@
 | validate_exception_date_range | exceptions | validate | before_save | Ensures to_date >= since_date |
 
 Rules created via Fyso MCP. Publish blocked by server-side bug (`{} is not iterable`) -- reported as feedback. Rules are in draft status and will be published once the bug is resolved.
+
+## 2026-03-28 — Computed Patient Name (#14)
+
+| Rule | Entity | Type | Trigger | Description |
+|------|--------|------|---------|-------------|
+| compute_patient_full_name | patients | compute | before_save (first_name, last_name) | Auto-sets `name` from `first_name + " " + last_name` |
+
+Rule created and published via Fyso MCP. Expression: `(first_name + ' ' + last_name).trim()`. Target field: `name`.


### PR DESCRIPTION
## Summary
Closes #14

Created and published business rule `compute_patient_full_name` on the `patients` entity via Fyso MCP. Auto-sets `name` from `first_name + " " + last_name` on every save.

## Changes
- Created rule in Fyso backend (already active)
- Added `docs/rules-changelog.md` documenting the rule

## Test Plan
- [ ] Create a patient with first_name="Juan" last_name="Perez" — verify name="Juan Perez"
- [ ] Update last_name to "Garcia" — verify name updates to "Juan Garcia"
- [ ] Existing patients unaffected until next save