### PR TITLE
feat: add validation rules for appointments, patients, exceptions

### DIFF
--- a/docs/rules-changelog.md
+++ b/docs/rules-changelog.md
@@ -1,0 +1,11 @@
+# Business Rules Changelog
+
+## 2026-03-28 — Validation Rules (#13)
+
+| Rule | Entity | Type | Trigger | Description |
+|------|--------|------|---------|-------------|
+| validate_appointment_date_future | appointments | validate | before_save | Rejects appointments with date in the past |
+| validate_patient_contact | patients | validate | before_save | Requires at least phone or email |
+| validate_exception_date_range | exceptions | validate | before_save | Ensures to_date >= since_date |
+
+Rules created via Fyso MCP. Publish blocked by server-side bug (`{} is not iterable`) -- reported as feedback. Rules are in draft status and will be published once the bug is resolved.


### PR DESCRIPTION
## Summary
Closes #13

Created 3 validation rules in Fyso backend via MCP:
- **validate_appointment_date_future**: rejects appointments with past dates
- **validate_patient_contact**: requires at least phone or email
- **validate_exception_date_range**: ensures to_date >= since_date

**Note**: Rules are in draft status — publish blocked by a server-side bug (`{} is not iterable`). Reported as feedback. Rules will be published once resolved.

## Changes
- `docs/rules-changelog.md`: documented all 3 rules

## Test Plan
- [ ] Verify rules exist in Fyso (draft status)
- [ ] Once publish bug is fixed: test each validation rejects invalid data
- [ ] Existing valid records are not affected