### PR TITLE
feat: namespace localStorage keys with tenant ID

### DIFF
--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -133,9 +133,12 @@ const sidebarLinks = [
       mobileOverlay?.addEventListener('click', toggleMenu);
       mobileClose?.addEventListener('click', toggleMenu);
 
+      const TENANT_ID = import.meta.env.PUBLIC_TENANT_ID || 'consultorio';
+      const TOKEN_KEY = `${TENANT_ID}_token`;
+      const USER_KEY = `${TENANT_ID}_user`;
       document.getElementById('logout-btn')?.addEventListener('click', () => {
-        localStorage.removeItem('consultorio_token');
-        localStorage.removeItem('consultorio_user');
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(USER_KEY);
         window.location.href = '/login';
       });
     </script>

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,8 +1,10 @@
 const BASE_URL = 'https://app.fyso.dev';
 const TENANT_ID = import.meta.env.PUBLIC_TENANT_ID || 'consultorio';
+const TOKEN_KEY = `${TENANT_ID}_token`;
+const USER_KEY = `${TENANT_ID}_user`;
 
 function getToken(): string | null {
-  return localStorage.getItem('consultorio_token');
+  return localStorage.getItem(TOKEN_KEY);
 }
 
 function getHeaders(): Record<string, string> {
@@ -16,8 +18,8 @@ function getHeaders(): Record<string, string> {
 }
 
 function handleUnauthorized() {
-  localStorage.removeItem('consultorio_token');
-  localStorage.removeItem('consultorio_user');
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
   window.location.href = '/login';
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,7 @@
 const BASE_URL = 'https://app.fyso.dev';
 const TENANT_ID = import.meta.env.PUBLIC_TENANT_ID || 'consultorio';
+const TOKEN_KEY = `${TENANT_ID}_token`;
+const USER_KEY = `${TENANT_ID}_user`;
 
 export async function login(email: string, password: string): Promise<{ success: boolean; error?: string }> {
   try {
@@ -21,9 +23,9 @@ export async function login(email: string, password: string): Promise<{ success:
     const token = data.data?.token || data.token;
     if (!token) return { success: false, error: 'No se recibio token' };
 
-    localStorage.setItem('consultorio_token', token);
+    localStorage.setItem(TOKEN_KEY, token);
     const user = data.data?.user || data.user || { email };
-    localStorage.setItem('consultorio_user', JSON.stringify(user));
+    localStorage.setItem(USER_KEY, JSON.stringify(user));
 
     return { success: true };
   } catch {
@@ -32,22 +34,22 @@ export async function login(email: string, password: string): Promise<{ success:
 }
 
 export function logout() {
-  localStorage.removeItem('consultorio_token');
-  localStorage.removeItem('consultorio_user');
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
   window.location.href = '/login';
 }
 
 export function isAuthenticated(): boolean {
-  return !!localStorage.getItem('consultorio_token');
+  return !!localStorage.getItem(TOKEN_KEY);
 }
 
 export function getUser(): any {
   try {
-    const raw = localStorage.getItem('consultorio_user');
+    const raw = localStorage.getItem(USER_KEY);
     return raw ? JSON.parse(raw) : null;
   } catch { return null; }
 }
 
 export function getToken(): string | null {
-  return localStorage.getItem('consultorio_token');
+  return localStorage.getItem(TOKEN_KEY);
 }

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -5,7 +5,8 @@ export interface CartItem {
   quantity: number;
 }
 
-const CART_KEY = 'consultorio_cart';
+const TENANT_ID = import.meta.env.PUBLIC_TENANT_ID || 'consultorio';
+const CART_KEY = `${TENANT_ID}_cart`;
 
 function notify() {
   window.dispatchEvent(new CustomEvent('cart-updated'));

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -93,7 +93,8 @@ import Layout from '../layouts/Layout.astro';
     // Update Google Maps iframe when config loads
     var checkMap = setInterval(function() {
       try {
-        var cached = sessionStorage.getItem('consultorio_site_config');
+        var tenantId = import.meta.env.PUBLIC_TENANT_ID || 'consultorio';
+        var cached = sessionStorage.getItem(tenantId + '_site_config');
         if (!cached) return;
         var parsed = JSON.parse(cached);
         var d = parsed.data;


### PR DESCRIPTION
## Summary
Closes #12

- Replace all hardcoded `consultorio_` prefixed localStorage/sessionStorage keys with dynamic ones derived from `PUBLIC_TENANT_ID` env var
- Defaults to `consultorio` for backward compatibility when no env var is set
- Covers auth.ts, api-client.ts, cart.ts, AdminLayout.astro logout, and contacto.astro site_config

## Changes
- `src/lib/auth.ts`: Added `TOKEN_KEY` and `USER_KEY` constants built from `TENANT_ID`; replaced all 7 hardcoded references
- `src/lib/api-client.ts`: Same pattern for `getToken()` and `handleUnauthorized()`
- `src/lib/cart.ts`: Added `TENANT_ID` constant; `CART_KEY` now uses template literal
- `src/layouts/AdminLayout.astro`: Inline logout script builds key names dynamically
- `src/pages/contacto.astro`: `sessionStorage` key for site_config uses tenant prefix

## Test Plan
- [ ] Set `PUBLIC_TENANT_ID=testclinic` in `.env`, login, verify localStorage keys are `testclinic_token` and `testclinic_user`
- [ ] Without env var, verify keys default to `consultorio_token` / `consultorio_user`
- [ ] Add item to cart, verify key is `{tenantId}_cart`
- [ ] Click logout in admin panel, verify correct keys are removed
- [ ] Visit /contacto, verify sessionStorage key uses tenant prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)