### PR TITLE
feat: replace hardcoded fallback text in layouts (#17)

### DIFF
--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -25,7 +25,7 @@ const sidebarLinks = [
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
-    <title>{title} | Consultorio</title>
+    <title>{title} | Admin</title>
   </head>
   <body class="bg-gray-50 text-gray-800 min-h-screen">
     <div class="flex min-h-screen">
@@ -33,8 +33,8 @@ const sidebarLinks = [
       <aside class="hidden lg:flex lg:flex-col lg:w-56 bg-gray-900 text-gray-300">
         <div class="p-4 border-b border-gray-700">
           <a href="/admin" class="flex items-center gap-2">
-            <div class="w-8 h-8 bg-teal-500 rounded-lg flex items-center justify-center text-white font-bold text-sm">C</div>
-            <span class="text-lg font-bold text-white">Consultorio</span>
+            <div class="w-8 h-8 bg-teal-500 rounded-lg flex items-center justify-center text-white font-bold text-sm" data-sc-initial="clinic_name">M</div>
+            <span class="text-lg font-bold text-white" data-sc="clinic_name">My Clinic</span>
           </a>
         </div>
         <nav class="flex-1 p-3 space-y-0.5">
@@ -87,8 +87,8 @@ const sidebarLinks = [
           <aside class="fixed left-0 top-0 h-full w-56 bg-gray-900 text-gray-300 z-50">
             <div class="p-4 border-b border-gray-700 flex items-center justify-between">
               <a href="/admin" class="flex items-center gap-2">
-                <div class="w-8 h-8 bg-teal-500 rounded-lg flex items-center justify-center text-white font-bold text-sm">C</div>
-                <span class="text-lg font-bold text-white">Consultorio</span>
+                <div class="w-8 h-8 bg-teal-500 rounded-lg flex items-center justify-center text-white font-bold text-sm" data-sc-initial="clinic_name">M</div>
+                <span class="text-lg font-bold text-white" data-sc="clinic_name">My Clinic</span>
               </a>
               <button id="admin-mobile-close" class="p-1 rounded-lg text-gray-400 hover:text-white">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
@@ -141,6 +141,24 @@ const sidebarLinks = [
         localStorage.removeItem(USER_KEY);
         window.location.href = '/login';
       });
+
+      // Apply site config to sidebar logo elements
+      function applySiteConfig(c) {
+        document.querySelectorAll("[data-sc]").forEach(function(el) {
+          var key = el.getAttribute("data-sc");
+          if (key && c[key]) el.textContent = c[key];
+        });
+        document.querySelectorAll("[data-sc-initial]").forEach(function(el) {
+          var key = el.getAttribute("data-sc-initial");
+          if (key && c[key]) el.textContent = c[key][0];
+        });
+      }
+
+      // Try to load site config from localStorage cache
+      try {
+        var cached = localStorage.getItem(TENANT_ID + "_site_config");
+        if (cached) applySiteConfig(JSON.parse(cached));
+      } catch(e) { /* ignore parse errors */ }
     </script>
   </body>
 </html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,12 +22,12 @@ const siteConfig: Record<string, string> = await fetchSiteConfig().catch(() => (
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Consultorio - Sistema de turnos online" />
+    <meta name="description" content="My Clinic - Sistema de turnos online" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
-    <title>{title} | Consultorio</title>
+    <title>{title} | {siteConfig.clinic_name || 'My Clinic'}</title>
   </head>
   <body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col">
     <!-- Navigation -->
@@ -36,9 +36,9 @@ const siteConfig: Record<string, string> = await fetchSiteConfig().catch(() => (
         <div class="flex items-center justify-between h-16">
           <a href="/" class="flex items-center gap-2 group">
             <div class="w-9 h-9 bg-teal-500 rounded-xl flex items-center justify-center text-white font-bold text-lg shadow-md shadow-teal-500/20 group-hover:shadow-lg group-hover:shadow-teal-500/30 transition-shadow" data-sc-initial="clinic_name">
-              C
+              {(siteConfig.clinic_name || 'M')[0]}
             </div>
-            <span class="text-xl font-bold text-gray-900" data-sc="clinic_name">Consultorio</span>
+            <span class="text-xl font-bold text-gray-900" data-sc="clinic_name">{siteConfig.clinic_name || 'My Clinic'}</span>
           </a>
 
           <div class="hidden md:flex items-center gap-1">
@@ -119,8 +119,8 @@ const siteConfig: Record<string, string> = await fetchSiteConfig().catch(() => (
         <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
           <div>
             <div class="flex items-center gap-2 mb-4">
-              <div class="w-8 h-8 bg-teal-500 rounded-lg flex items-center justify-center text-white font-bold" data-sc-initial="clinic_name">C</div>
-              <span class="text-lg font-bold text-white" data-sc="clinic_name">Consultorio</span>
+              <div class="w-8 h-8 bg-teal-500 rounded-lg flex items-center justify-center text-white font-bold" data-sc-initial="clinic_name">{(siteConfig.clinic_name || 'M')[0]}</div>
+              <span class="text-lg font-bold text-white" data-sc="clinic_name">{siteConfig.clinic_name || 'My Clinic'}</span>
             </div>
             <p class="text-sm" data-sc="clinic_slogan">Tu consultorio de confianza. Turnos online las 24 horas.</p>
           </div>
@@ -174,7 +174,7 @@ const siteConfig: Record<string, string> = await fetchSiteConfig().catch(() => (
           });
         }
         if (c.clinic_name) {
-          document.title = document.title.replace('Consultorio', c.clinic_name);
+          document.title = document.title.replace('My Clinic', c.clinic_name);
         }
       }
     </script>


### PR DESCRIPTION
## Summary
- Replaced all hardcoded "Consultorio" fallback text in `Layout.astro` and `AdminLayout.astro` with generic "My Clinic" defaults
- Added `data-sc="clinic_name"` and `data-sc-initial="clinic_name"` attributes to AdminLayout sidebar logo elements (both desktop and mobile) so `applySiteConfig()` can update them dynamically
- Added `applySiteConfig()` function to AdminLayout that reads site config from localStorage cache
- Layout.astro now uses server-side `siteConfig.clinic_name` for initial render (title, nav logo, footer logo)

## Test plan
- [ ] Verify Layout.astro renders "My Clinic" as default when no site_config is set
- [ ] Verify AdminLayout sidebar shows "My Clinic" / "M" as default
- [ ] Verify site_config overrides still work in both layouts
- [ ] Verify no hardcoded "Consultorio" remains in layout files

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)