### PR TITLE
feat: migrate doctors.specialization to system specialty

### DIFF
--- a/src/components/react/DoctorsPage.tsx
+++ b/src/components/react/DoctorsPage.tsx
@@ -108,7 +108,7 @@ export default function DoctorsPage() {
                         {d.online ? 'Si' : 'No'}
                       </span>
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{d.specialization || '-'}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{d.specialty || '-'}</td>
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-1">
                         <button

--- a/src/components/react/TurnosPage.tsx
+++ b/src/components/react/TurnosPage.tsx
@@ -228,8 +228,8 @@ export default function TurnosPage() {
                       <div className="flex items-center justify-between">
                         <div>
                           <p className="font-semibold text-gray-900 group-hover:text-teal-700">{doc.data?.name}</p>
-                          {doc.data?.specialization && (
-                            <p className="text-sm text-gray-500 mt-0.5">{doc.data.specialization}</p>
+                          {doc.data?.specialty && (
+                            <p className="text-sm text-gray-500 mt-0.5">{doc.data.specialty}</p>
                           )}
                           {doc.data?.nota_publica && (
                             <p className="text-xs text-gray-400 mt-1">{doc.data.nota_publica}</p>

--- a/src/lib/entities.ts
+++ b/src/lib/entities.ts
@@ -30,7 +30,7 @@ export const doctorsConfig: EntityConfig = {
   displayField: 'name',
   fields: [
     { key: 'name', label: 'Nombre completo', type: 'text', required: true, showInTable: true },
-    { key: 'specialization', label: 'Especialidad', type: 'text', showInTable: true },
+    { key: 'specialty', label: 'Especialidad', type: 'text', showInTable: true },
     { key: 'email', label: 'Email', type: 'email', showInTable: true },
     { key: 'enabled', label: 'Habilitado', type: 'boolean', showInTable: true },
     { key: 'online', label: 'Turnos Online', type: 'boolean', showInTable: true },


### PR DESCRIPTION
## Summary
- Replaces all frontend references from custom `specialization` field to the system `specialty` field on the doctors entity
- No data migration needed: the only doctor record has neither field populated

Closes #34

## Changes
- `src/lib/entities.ts`: field key `specialization` -> `specialty`
- `src/components/react/TurnosPage.tsx`: `doc.data.specialization` -> `doc.data.specialty`
- `src/components/react/DoctorsPage.tsx`: `d.specialization` -> `d.specialty`

## Test Plan
- [ ] Verify doctors list page shows specialty column correctly
- [ ] Verify turnos page shows doctor specialty in selection step
- [ ] Verify creating/editing a doctor saves to `specialty` field
- [ ] `npx tsc --noEmit` passes (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)